### PR TITLE
Use correct Cattedrale font family

### DIFF
--- a/cod.py
+++ b/cod.py
@@ -26,7 +26,10 @@ class Application(tk.Tk):
         # Регистрация и настройка шрифта
         ctypes.windll.gdi32.AddFontResourceExW(font_path, 0x10, 0)
         default_font = tkfont.nametofont("TkDefaultFont")
-        custom_font = tkfont.Font(family="Cattedrale", size=default_font.cget("size"))
+        custom_font = tkfont.Font(
+            family="Cattedrale [RUS by penka220]",
+            size=default_font.cget("size"),
+        )
         self.option_add("*Font", custom_font)
 
         # Стиль для виджетов


### PR DESCRIPTION
## Summary
- Use the exact registered font name "Cattedrale [RUS by penka220]" for Tkinter widgets

## Testing
- `python -m py_compile cod.py`
- `python cod.py` *(fails: _tkinter.TclError: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_689e3812db508332b54d7515231228b9