### PR TITLE
Use tkinter/ttk instead of customtkinter

### DIFF
--- a/cod.py
+++ b/cod.py
@@ -1,7 +1,6 @@
 import tkinter as tk
-from tkinter import simpledialog, filedialog
+from tkinter import simpledialog, filedialog, ttk
 from tkinter import font as tkfont
-import customtkinter as ctk
 import ctypes
 import os
 import time
@@ -10,11 +9,30 @@ from docx import Document
 # Path to store window size
 CONFIG_PATH = os.path.join(os.path.dirname(__file__), "window_size.txt")
 
-class Application(ctk.CTk):
+class Application(tk.Tk):
     def __init__(self):
         super().__init__()
 
-        ctk.set_appearance_mode("dark")
+        style = ttk.Style(self)
+        style.theme_use("clam")
+
+        style.configure("Custom.TFrame", background="#2f2f2f")
+        style.configure("Custom.TLabel", background="#2f2f2f", foreground="#eeeeee")
+        style.configure(
+            "Custom.TButton",
+            background="#eeeeee",
+            foreground="#313131",
+            borderwidth=2,
+            padding=6,
+            relief="flat",
+        )
+        style.map("Custom.TButton", background=[("active", "#ffffff")])
+        style.configure(
+            "Custom.TEntry",
+            foreground="#303030",
+            fieldbackground="#ffffff",
+            borderwidth=2,
+        )
 
         # Создаем окно перед настройкой шрифта
         self.title("Генератор Глав")
@@ -28,7 +46,7 @@ class Application(ctk.CTk):
                 self.geometry("500x400")  # Размер окна
         else:
             self.geometry("500x400")  # Размер окна
-        self.configure(fg_color="#2f2f2f")  # Темно-серый фон
+        self.configure(bg="#2f2f2f")  # Темно-серый фон
         self.resizable(True, True)
         self.protocol("WM_DELETE_WINDOW", self.on_closing)
 
@@ -48,47 +66,40 @@ class Application(ctk.CTk):
         )
         self.option_add("*Font", custom_font)
 
-        button_params = {
-            "corner_radius": 12,
-            "border_color": "white",
-            "border_width": 2,
-            "fg_color": "#eeeeee",
-            "hover_color": "#ffffff",
-            "text_color": "#313131",
-            "font": custom_font,
-        }
-
-        entry_params = {
-            "corner_radius": 12,
-            "border_color": "white",
-            "border_width": 2,
-            "fg_color": "#ffffff",
-            "text_color": "#303030",
-            "font": default_font,
-        }
-
         # Создаем рамку для текста
-        self.frame = ctk.CTkFrame(self, fg_color="#2f2f2f")
+        self.frame = ttk.Frame(self, style="Custom.TFrame")
         self.frame.pack(padx=20, pady=20, expand=True, fill="both")
 
         # Создаем метку
         header_font = tkfont.Font(family=custom_font.actual("family"), size=16, weight="bold")
-        self.label = ctk.CTkLabel(self.frame, text="Генератор Глав", text_color="#eeeeee", font=header_font)
+        self.label = ttk.Label(self.frame, text="Генератор Глав", font=header_font, style="Custom.TLabel")
         self.label.pack(pady=20)
 
         # Кнопки для взаимодействия
-        self.ask_button = ctk.CTkButton(self.frame, text="Начать генерацию", command=self.ask_questions, **button_params)
+        self.ask_button = ttk.Button(
+            self.frame,
+            text="Начать генерацию",
+            command=self.ask_questions,
+            style="Custom.TButton",
+        )
         self.ask_button.pack(pady=10)
 
         # Поле для ввода пути с кнопкой
-        self.path_label = ctk.CTkLabel(self.frame, text="Выберите путь для сохранения:", text_color="#eeeeee")
+        self.path_label = ttk.Label(
+            self.frame, text="Выберите путь для сохранения:", style="Custom.TLabel"
+        )
         self.path_label.pack(pady=10)
 
-        self.path_entry = ctk.CTkEntry(self.frame, **entry_params)
+        self.path_entry = ttk.Entry(self.frame, style="Custom.TEntry")
         self.path_entry.pack(fill=tk.X, padx=10, pady=5)
 
         # Кнопка для выбора папки
-        self.browse_button = ctk.CTkButton(self.frame, text="Выбрать папку", command=self.browse_folder, **button_params)
+        self.browse_button = ttk.Button(
+            self.frame,
+            text="Выбрать папку",
+            command=self.browse_folder,
+            style="Custom.TButton",
+        )
         self.browse_button.pack(pady=5)
 
     def browse_folder(self):
@@ -141,24 +152,22 @@ class Application(ctk.CTk):
         self.destroy()
 
     def show_popup(self, message, color="green"):
-        popup = ctk.CTkToplevel(self)
+        popup = tk.Toplevel(self)
         popup.geometry("300x100")
         popup.title("Результат")
-        popup.configure(fg_color="#2f2f2f")
+        popup.configure(bg="#2f2f2f")
 
-        label = ctk.CTkLabel(popup, text=message, text_color=color)
+        style = ttk.Style(popup)
+        style.configure("Popup.TLabel", background="#2f2f2f", foreground=color)
+
+        label = ttk.Label(popup, text=message, style="Popup.TLabel")
         label.pack(pady=20)
 
-        close_button = ctk.CTkButton(
+        close_button = ttk.Button(
             popup,
             text="Закрыть",
             command=popup.destroy,
-            corner_radius=12,
-            border_color="white",
-            border_width=2,
-            fg_color="#eeeeee",
-            hover_color="#ffffff",
-            text_color="#313131",
+            style="Custom.TButton",
         )
         close_button.pack()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 python-docx
 Pillow
-customtkinter
-customtkinter


### PR DESCRIPTION
## Summary
- replace customtkinter with tkinter/ttk widgets
- define ttk styles to maintain the app's dark theme and button/entry colors
- remove customtkinter from requirements

## Testing
- `python -m py_compile cod.py`


------
https://chatgpt.com/codex/tasks/task_e_689f0519fa4c8332a898f34b512029b0