### PR TITLE
Use correct Cattedrale font family

### DIFF
--- a/cod.py
+++ b/cod.py
@@ -24,7 +24,7 @@ class Application(tk.Tk):
         ctypes.windll.gdi32.AddFontResourceExW(font_path, 0x10, 0)
         default_font = tkfont.nametofont("TkDefaultFont")
         custom_font = tkfont.Font(
-            family="Cattedrale",
+            family="Cattedrale [RUS by penka220]",
             size=default_font.cget("size") + 2,
         )
         self.custom_font = custom_font


### PR DESCRIPTION
## Summary
- switch Tk font family to the actual name `Cattedrale [RUS by penka220]`.

## Testing
- `xvfb-run -a timeout 5 python cod.py` *(fails: module 'ctypes' has no attribute 'windll')*
- `python -m py_compile cod.py`


------
https://chatgpt.com/codex/tasks/task_e_689f13713ea48332b5dd72cf3ad5856e