### PR TITLE
Add customtkinter dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 python-docx
 Pillow
-customtkinter  # GUI framework
+customtkinter


### PR DESCRIPTION
## Summary
- ensure customtkinter is listed in requirements for GUI

## Testing
- `pip install customtkinter`
- `python cod.py` *(fails: _tkinter.TclError: no display name and no $DISPLAY environment variable)*
- `python -m py_compile cod.py`


------
https://chatgpt.com/codex/tasks/task_e_689f317d01a88332a29af755b11403db