### PR TITLE
Adjust path entry styling

### DIFF
--- a/cod.py
+++ b/cod.py
@@ -140,7 +140,8 @@ class Application(tk.Tk):
             fg_color="#ffffff",
             text_color="#303030",
             border_color="#2f2f2f",
-            border_width=2,
+            border_width=0,
+            bg_color="#2f2f2f",
             font=self.custom_font,
         )
         self.path_entry.pack(fill=tk.X, padx=10, pady=5)


### PR DESCRIPTION
## Summary
- tweak CTkEntry for path selection to blend with dark UI

## Testing
- `pytest -q`
- `python -m py_compile cod.py`


------
https://chatgpt.com/codex/tasks/task_e_689f3e02e2048332bb02015cfa355910