### PR TITLE
Increase default and header fonts

### DIFF
--- a/cod.py
+++ b/cod.py
@@ -62,7 +62,7 @@ class Application(tk.Tk):
         default_font = tkfont.nametofont("TkDefaultFont")
         custom_font = ctk.CTkFont(
             family=font_family,
-            size=default_font.cget("size") + 2,
+            size=default_font.cget("size") + 4,
         )
         self.custom_font = custom_font
         self.option_add("*Font", custom_font)
@@ -93,7 +93,7 @@ class Application(tk.Tk):
         self.frame.pack(padx=20, pady=20, expand=True, fill="both")
 
         # Создаем метку
-        header_font = ctk.CTkFont(family=custom_font.actual("family"), size=16, weight="bold")
+        header_font = ctk.CTkFont(family=custom_font.actual("family"), size=18, weight="bold")
         self.label = ttk.Label(self.frame, text="Генератор Глав", font=header_font, style="Custom.TLabel")
         self.label.pack(pady=20)
 


### PR DESCRIPTION
## Summary
- enlarge application custom font by basing size on default font + 4
- increase header font size to 18 for better readability

## Testing
- `python -m py_compile cod.py`


------
https://chatgpt.com/codex/tasks/task_e_689f488f854483328050eb6eaccae058