### PR TITLE
Remove window title

### DIFF
--- a/cod.py
+++ b/cod.py
@@ -74,7 +74,7 @@ class Application(tk.Tk):
         self.style.configure("Custom.TLabel", background="#2f2f2f", foreground="#eeeeee")
 
         # Создаем окно перед настройкой шрифта
-        self.title("Генератор Глав")
+        self.title("")
         # Set window geometry
         saved_geom = ""
         if os.path.exists(CONFIG_PATH):


### PR DESCRIPTION
## Summary
- Clear application window title and keep title only in header label

## Testing
- `python -m py_compile cod.py`


------
https://chatgpt.com/codex/tasks/task_e_689f4b52a7e483329d8615e938e2c243