### PR TITLE
Add background color for interface buttons

### DIFF
--- a/cod.py
+++ b/cod.py
@@ -106,6 +106,7 @@ class Application(tk.Tk):
             border_width=0,
             fg_color="#313131",
             hover_color="#3e3e3e",
+            bg_color="#2f2f2f",
             font=self.custom_font,
         )
         self.ask_button.pack(pady=10)
@@ -137,6 +138,7 @@ class Application(tk.Tk):
             border_width=0,
             fg_color="#313131",
             hover_color="#3e3e3e",
+            bg_color="#2f2f2f",
             font=self.custom_font,
         )
         self.browse_button.pack(pady=10)


### PR DESCRIPTION
## Summary
- Ensure `ask_button` and `browse_button` use the dark background color `#2f2f2f` for consistency with the app's style

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f51240bc4833280c020123d0ceca5