### PR TITLE
Replace GlowButton with CTkButton

### DIFF
--- a/cod.py
+++ b/cod.py
@@ -15,7 +15,6 @@ from tkinter import font as tkfont
 
 import customtkinter as ctk
 from docx import Document
-from glow_button import GlowButton
 
 # Path to store window geometry
 CONFIG_PATH = os.path.join(os.path.dirname(__file__), "window.cfg")
@@ -99,10 +98,11 @@ class Application(tk.Tk):
         self.label.pack(pady=20)
 
         # Кнопка для начала генерации
-        self.ask_button = GlowButton(
+        self.ask_button = ctk.CTkButton(
             self.frame,
             text="Начать генерацию",
             command=self.ask_questions,
+            corner_radius=12,
             fg_color="#313131",
             hover_color="#3e3e3e",
             bg_color="#2f2f2f",
@@ -129,10 +129,11 @@ class Application(tk.Tk):
         self.path_entry.pack(fill=tk.X, padx=10, pady=5)
 
         # Кнопка для выбора папки
-        self.browse_button = GlowButton(
+        self.browse_button = ctk.CTkButton(
             self.frame,
             text="Выбрать папку",
             command=self.browse_folder,
+            corner_radius=12,
             fg_color="#313131",
             hover_color="#3e3e3e",
             bg_color="#2f2f2f",


### PR DESCRIPTION
## Summary
- replace custom GlowButton usage with ctk.CTkButton
- style and pack the buttons with consistent parameters

## Testing
- `python -m py_compile cod.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0204e370c8332abec92cc9c074959