### PR TITLE
style: customize input dialogs

### DIFF
--- a/cod.py
+++ b/cod.py
@@ -151,6 +151,13 @@ class Application(tk.Tk):
         total_dialog = ctk.CTkInputDialog(
             title="Сколько ебануть?",
             text="Введите количество глав:",
+            text_font=self.custom_font,
+            button_font=self.custom_font,
+            fg_color="#2f2f2f",
+            text_color="#eeeeee",
+            button_fg_color="#313131",
+            button_hover_color="#3e3e3e",
+            button_corner_radius=12,
         )
         total_chapters = total_dialog.get_input()
         if total_chapters is None:
@@ -160,6 +167,13 @@ class Application(tk.Tk):
         parts_dialog = ctk.CTkInputDialog(
             title="На сколько делим епт?",
             text="Введите количество частей в главе:",
+            text_font=self.custom_font,
+            button_font=self.custom_font,
+            fg_color="#2f2f2f",
+            text_color="#eeeeee",
+            button_fg_color="#313131",
+            button_hover_color="#3e3e3e",
+            button_corner_radius=12,
         )
         parts_per_chapter = parts_dialog.get_input()
         if parts_per_chapter is None:


### PR DESCRIPTION
## Summary
- style CTkInputDialog prompts with custom fonts, colors, and rounded buttons
- keep converting dialog inputs to integers

## Testing
- `python -m py_compile cod.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0233f2bb883329907dfd6e22bb0bb