### PR TITLE
Remove button_corner_radius usage for dialogs

### DIFF
--- a/cod.py
+++ b/cod.py
@@ -155,10 +155,11 @@ class Application(tk.Tk):
             fg_color="#2f2f2f",
             button_fg_color="#313131",
             button_hover_color="#3e3e3e",
-            button_corner_radius=12,
         )
         total_dialog._label.configure(font=self.custom_font, text_color="#eeeeee")
         total_dialog._entry.configure(font=self.custom_font)
+        total_dialog._ok_button.configure(corner_radius=12)
+        total_dialog._cancel_button.configure(corner_radius=12)
         total_dialog._ok_button.configure(font=self.custom_font)
         total_dialog._cancel_button.configure(font=self.custom_font)
 
@@ -173,10 +174,11 @@ class Application(tk.Tk):
             fg_color="#2f2f2f",
             button_fg_color="#313131",
             button_hover_color="#3e3e3e",
-            button_corner_radius=12,
         )
         parts_dialog._label.configure(font=self.custom_font, text_color="#eeeeee")
         parts_dialog._entry.configure(font=self.custom_font)
+        parts_dialog._ok_button.configure(corner_radius=12)
+        parts_dialog._cancel_button.configure(corner_radius=12)
         parts_dialog._ok_button.configure(font=self.custom_font)
         parts_dialog._cancel_button.configure(font=self.custom_font)
 


### PR DESCRIPTION
## Summary
- configure dialog buttons with rounded corners after creation
- drop button_corner_radius from CTkInputDialog calls

## Testing
- `python -m py_compile cod.py`


------
https://chatgpt.com/codex/tasks/task_e_68a02a19bfa88332bf65879233740364