### PR TITLE
Use light palette for path entry and remove border

### DIFF
--- a/cod.py
+++ b/cod.py
@@ -121,8 +121,8 @@ class Application(tk.Tk):
         self.path_entry = ctk.CTkEntry(
             self.frame,
             corner_radius=12,
-            fg_color="#313131",
-            text_color="#eeeeee",
+            fg_color="#ffffff",
+            text_color="#303030",
             border_color="#2f2f2f",
             border_width=0,
             bg_color="#2f2f2f",


### PR DESCRIPTION
## Summary
- Revert path entry widget to light palette with white background, dark text, and no border.

## Testing
- `python -m py_compile cod.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a04206f0988332baf26c72b2fae8e6