### PR TITLE
Enhance save path entry placeholder

### DIFF
--- a/cod.py
+++ b/cod.py
@@ -114,13 +114,9 @@ class Application(tk.Tk):
         self.ask_button.pack(pady=10)
 
         # Поле для ввода пути с кнопкой
-        self.path_label = ttk.Label(
-            self.frame, text="Выберите путь для сохранения:", style="Custom.TLabel"
-        )
-        self.path_label.pack(pady=10)
-
         self.path_entry = ctk.CTkEntry(
             self.frame,
+            placeholder_text="Куда сейвим?",
             corner_radius=12,
             fg_color="#ffffff",
             text_color="#303030",


### PR DESCRIPTION
## Summary
- remove the label prompting for save path
- add a save path entry with placeholder text "Куда сейвим?"

## Testing
- `python -m py_compile cod.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0545a80588332bced6e0bfaa6fb04