### PR TITLE
Clear default icons for input dialogs

### DIFF
--- a/cod.py
+++ b/cod.py
@@ -204,6 +204,7 @@ class Application(tk.Tk):
             entry_text_color="#303030",
             font=self.custom_font,
         )
+        total_dialog.iconbitmap("")
         style_dialog(total_dialog, "Введите количество глав:")
 
         total_chapters = total_dialog.get_input()
@@ -223,6 +224,7 @@ class Application(tk.Tk):
             entry_text_color="#303030",
             font=self.custom_font,
         )
+        parts_dialog.iconbitmap("")
         style_dialog(parts_dialog, "Введите количество частей в главе:")
 
         parts_per_chapter = parts_dialog.get_input()


### PR DESCRIPTION
## Summary
- Ensure CTkInputDialog windows don't display a default icon by clearing it with `iconbitmap("")`

## Testing
- `python -m py_compile cod.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0583c8e30833293df39d16e31db8a