### PR TITLE
Ensure dialogs show no icon

### DIFF
--- a/cod.py
+++ b/cod.py
@@ -204,8 +204,8 @@ class Application(tk.Tk):
             entry_text_color="#303030",
             font=self.custom_font,
         )
-        total_dialog.iconbitmap("")
         style_dialog(total_dialog, "Введите количество глав:")
+        total_dialog.iconbitmap("")
 
         total_chapters = total_dialog.get_input()
         if total_chapters is None:
@@ -224,8 +224,8 @@ class Application(tk.Tk):
             entry_text_color="#303030",
             font=self.custom_font,
         )
-        parts_dialog.iconbitmap("")
         style_dialog(parts_dialog, "Введите количество частей в главе:")
+        parts_dialog.iconbitmap("")
 
         parts_per_chapter = parts_dialog.get_input()
         if parts_per_chapter is None:


### PR DESCRIPTION
## Summary
- call `iconbitmap("")` on each CTkInputDialog to remove default icons

## Testing
- `python -m py_compile cod.py`


------
https://chatgpt.com/codex/tasks/task_e_68a05cc72a548332bc5e2687a1e7038b