### PR TITLE
Remove window icon from Application

### DIFF
--- a/cod.py
+++ b/cod.py
@@ -4,7 +4,6 @@ The application registers the bundled 'Cattedrale' font from the local fonts
 directory so the font file must be available on disk.
 """
 
-import base64
 import ctypes
 import os
 import sys
@@ -18,21 +17,6 @@ from docx import Document
 
 # Path to store window geometry
 CONFIG_PATH = os.path.join(os.path.dirname(__file__), "window.cfg")
-
-ICON_PNG_B64 = (
-    "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAr0lEQVR4nO3QLW5CQRAA4C9F9AYVCBxp0jOAqCAQwgEqMfQInILgcEU0XABFguIW3ACFwlY0NSNe1rS8"
-    "lCfIfGp2fnYnS0oppTuxxkOdwVpDhUd84bvJBXqV+BWHiPu3XqCLTwwquSH2EY+wib5/t8AST0V+XZzbWEXvr675gQ5OuFRyLzgWfefIta+4+8/G2GEa5zmeK/U3bKPv"
-    "Zlp4j/ijqM2i3phJk4+llFK6Tz/HBhQcv0+QOQAAAABJRU5ErkJggg=="
-)
-
-
-def ensure_icon(path: str) -> None:
-    """Create the icon file from embedded data if it is missing."""
-    if not os.path.exists(path):
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        with open(path, "wb") as f:
-            f.write(base64.b64decode(ICON_PNG_B64))
-
 
 class CustomInputDialog(ctk.CTkToplevel):
     """Simple dialog asking the user for a single line of text."""
@@ -106,10 +90,7 @@ class CustomInputDialog(ctk.CTkToplevel):
 class Application(tk.Tk):
     def __init__(self):
         super().__init__()
-        icon_path = os.path.join(os.path.dirname(__file__), "icons", "code.png")
-        ensure_icon(icon_path)
-        self.icon_path = icon_path
-        self.iconphoto(True, tk.PhotoImage(file=icon_path))
+        self.iconbitmap("")
 
         self.config_data = self.load_config()
 


### PR DESCRIPTION
## Summary
- remove embedded icon resources and iconphoto usage in the main Application
- call `self.iconbitmap("")` after window creation to show no title bar icon

## Testing
- `python -m py_compile cod.py`


------
https://chatgpt.com/codex/tasks/task_e_68a05f67ac248332b75c6d53131a7548