### PR TITLE
Increase header font size

### DIFF
--- a/cod.py
+++ b/cod.py
@@ -158,7 +158,7 @@ class Application(tk.Tk):
 
         # Создаем метку
         header_font = ctk.CTkFont(
-            family=custom_font.actual("family"), size=20, weight="bold"
+            family=custom_font.actual("family"), size=25, weight="bold"
         )
         self.label = ttk.Label(self.frame, text="Генератор Глав", font=header_font, style="Custom.TLabel")
         self.label.pack(pady=20)


### PR DESCRIPTION
## Summary
- increase `header_font` size from 20 to 25 for larger text in generator

## Testing
- `python -m py_compile cod.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0710aa9b48332a9909ff0d1b2458d