### PR TITLE
Add popup color parameter and propagate messages

### DIFF
--- a/cod.py
+++ b/cod.py
@@ -410,10 +410,10 @@ class Application(tk.Tk):
         self.show_message(f"Создано {total_chapters * parts_per_chapter} файлов в папке {folder_for_chapters}")
 
     def show_message(self, message):
-        self.show_popup("Готово, епт")
+        self.show_popup(message)
 
     def show_error(self, message):
-        self.show_popup("Готово, епт")
+        self.show_popup(message, color="#ff0000")
 
     def on_closing(self):
         self.config_data["geometry"] = self.geometry()
@@ -421,7 +421,7 @@ class Application(tk.Tk):
         self.save_config()
         self.destroy()
 
-    def show_popup(self, message):
+    def show_popup(self, message, color="#00ff00"):
         popup = ctk.CTkToplevel(self, fg_color="#2f2f2f")
         popup.iconbitmap(self.icon_path)
         popup.title("")
@@ -433,7 +433,7 @@ class Application(tk.Tk):
         label = ctk.CTkLabel(
             frame,
             text=message,
-            text_color="#00ff00",
+            text_color=color,
             font=ctk.CTkFont(
                 family=self.custom_font.actual("family"),
                 size=self.custom_font.cget("size"),


### PR DESCRIPTION
## Summary
- Forward message text to popup in both success and error handlers
- Allow popup to customize text color, using red for errors

## Testing
- `python -m py_compile cod.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd1806328483328e56d237523986eb