### PR TITLE
Add tests for document splitting and English word detection

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest

--- a/tests/test_cod.py
+++ b/tests/test_cod.py
@@ -1,0 +1,46 @@
+import os
+import re
+import sys
+from pathlib import Path
+from docx import Document
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from cod import split_document, check_english_words
+
+def create_sample_doc(path):
+    doc = Document()
+    doc.add_paragraph("Глава 1")
+    doc.add_paragraph("Text for chapter 1")
+    doc.add_paragraph("Глава 1.1")
+    doc.add_paragraph("Text for chapter 1.1")
+    doc.add_paragraph("Глава 2")
+    doc.add_paragraph("Text for chapter 2")
+    doc.save(path)
+
+
+def test_split_document(tmp_path):
+    source = tmp_path / "source.docx"
+    create_sample_doc(source)
+
+    created_files = split_document(str(source))
+
+    expected_names = {"Глава 1.docx", "Глава 1.1.docx", "Глава 2.docx"}
+    assert {os.path.basename(p) for p in created_files} == expected_names
+
+    heading_pattern = re.compile(r"^Глава\s+\d+(?:\.\d+)?")
+    for file_name in expected_names:
+        doc = Document(tmp_path / file_name)
+        texts = [p.text.strip() for p in doc.paragraphs if p.text.strip()]
+        assert all(not heading_pattern.match(t) for t in texts)
+
+
+def test_check_english_words(tmp_path):
+    path = tmp_path / "english.docx"
+    doc = Document()
+    doc.add_paragraph("Привет Hello мир")
+    doc.add_paragraph("Это Test документ")
+    doc.add_paragraph("Другие слова: World, Hello")
+    doc.save(path)
+
+    words = check_english_words(str(path))
+    assert words == ["Hello", "Test", "World"]


### PR DESCRIPTION
## Summary
- add pure helpers for splitting DOCX files into chapters and for extracting English words
- cover document splitting and English-word detection with pytest tests
- run tests in CI via GitHub Actions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd21edaa608332bd9364a476695686