### PR TITLE
Prompt user for output directory when splitting document

### DIFF
--- a/cod.py
+++ b/cod.py
@@ -34,10 +34,15 @@ def split_document(file_path: str) -> List[str]:
     """
 
     heading_pattern = re.compile(r"^Глава\s+\d+(?:\.\d+)?")
+    output_dir = filedialog.askdirectory(
+        title="Выберите выходной каталог",
+        initialdir=os.path.dirname(file_path),
+    )
+    if not output_dir:
+        output_dir = os.path.dirname(file_path)
     document = Document(file_path)
     current_doc = None
     current_title = ""
-    output_dir = os.path.dirname(file_path)
     created_files: List[str] = []
 
     for para in document.paragraphs:

--- a/tests/test_cod.py
+++ b/tests/test_cod.py
@@ -3,6 +3,7 @@ import re
 import sys
 from pathlib import Path
 from docx import Document
+from unittest.mock import patch
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from cod import split_document, check_english_words
@@ -22,7 +23,8 @@ def test_split_document(tmp_path):
     source = tmp_path / "source.docx"
     create_sample_doc(source)
 
-    created_files = split_document(str(source))
+    with patch("cod.filedialog.askdirectory", return_value=str(tmp_path)):
+        created_files = split_document(str(source))
 
     expected_names = {"Глава 1.docx", "Глава 1.1.docx", "Глава 2.docx"}
     assert {os.path.basename(p) for p in created_files} == expected_names


### PR DESCRIPTION
## Summary
- Allow users to choose an output folder via `filedialog.askdirectory` when splitting DOCX files
- Update tests to mock the output directory selection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd2a6aa49c8332af03692bfff85024