### PR TITLE
Add tests for DOCX splitting and English word extraction

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 python-docx
 Pillow
 customtkinter
+pytest

--- a/tests/test_check_english_words.py
+++ b/tests/test_check_english_words.py
@@ -1,0 +1,27 @@
+import os
+import sys
+from pathlib import Path
+
+from docx import Document
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from cod import check_english_words
+
+
+def test_check_english_words(tmp_path):
+    path = tmp_path / "english.docx"
+    doc = Document()
+    doc.add_paragraph("Привет Hello мир")
+    doc.add_paragraph("Это Test документ")
+    doc.add_paragraph("Другие слова: World, Hello")
+    doc.save(path)
+
+    words = check_english_words(str(path))
+    assert words == ["Hello", "Test", "World"]
+
+    save_path = tmp_path / "words.txt"
+    with open(save_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(words))
+
+    assert save_path.read_text(encoding="utf-8") == "Hello\nTest\nWorld"
+

--- a/tests/test_split_document.py
+++ b/tests/test_split_document.py
@@ -2,11 +2,13 @@ import os
 import re
 import sys
 from pathlib import Path
-from docx import Document
 from unittest.mock import patch
 
+from docx import Document
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from cod import split_document, check_english_words
+from cod import split_document
+
 
 def create_sample_doc(path):
     doc = Document()
@@ -35,14 +37,3 @@ def test_split_document(tmp_path):
         texts = [p.text.strip() for p in doc.paragraphs if p.text.strip()]
         assert all(not heading_pattern.match(t) for t in texts)
 
-
-def test_check_english_words(tmp_path):
-    path = tmp_path / "english.docx"
-    doc = Document()
-    doc.add_paragraph("Привет Hello мир")
-    doc.add_paragraph("Это Test документ")
-    doc.add_paragraph("Другие слова: World, Hello")
-    doc.save(path)
-
-    words = check_english_words(str(path))
-    assert words == ["Hello", "Test", "World"]


### PR DESCRIPTION
## Summary
- add `pytest` as a project requirement
- cover `split_document` and `check_english_words` with dedicated tests

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd326270b483328d2bab7ff7389cb9