### PR TITLE
Track positions of English words

### DIFF
--- a/tests/test_check_english_words.py
+++ b/tests/test_check_english_words.py
@@ -17,11 +17,22 @@ def test_check_english_words(tmp_path):
     doc.save(path)
 
     words = check_english_words(str(path))
-    assert words == ["Hello", "Test", "World"]
+    assert words == {
+        "Hello": [(1, 8), (3, 22)],
+        "Test": [(2, 5)],
+        "World": [(3, 15)],
+    }
 
     save_path = tmp_path / "words.txt"
+    lines = [
+        f"{word} - {', '.join(str(p) for p, _ in positions)}"
+        for word, positions in words.items()
+    ]
     with open(save_path, "w", encoding="utf-8") as f:
-        f.write("\n".join(words))
+        f.write("\n".join(lines))
 
-    assert save_path.read_text(encoding="utf-8") == "Hello\nTest\nWorld"
+    assert (
+        save_path.read_text(encoding="utf-8")
+        == "Hello - 1, 3\nTest - 2\nWorld - 3"
+    )
 


### PR DESCRIPTION
## Summary
- Store paragraph and character positions for each English word in DOCX files
- Display English words and their paragraph numbers in a popup table
- Update tests to verify word positions and saved output format

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd36e2a24083329930cc3c2f6581d7