### PR TITLE
Ensure unique chapter filenames in split_document

### DIFF
--- a/cod.py
+++ b/cod.py
@@ -45,6 +45,15 @@ def split_document(file_path: str) -> List[str]:
     current_title = ""
     created_files: List[str] = []
 
+    def _unique_path(directory: str, filename: str) -> str:
+        base, ext = os.path.splitext(filename)
+        candidate = os.path.join(directory, filename)
+        counter = 2
+        while os.path.exists(candidate):
+            candidate = os.path.join(directory, f"{base} ({counter}){ext}")
+            counter += 1
+        return candidate
+
     for para in document.paragraphs:
         text = para.text.strip()
         if heading_pattern.match(text):
@@ -53,7 +62,7 @@ def split_document(file_path: str) -> List[str]:
                 if not sanitized:
                     sanitized = "section"
                 file_name = f"{sanitized}.docx"
-                out_path = os.path.join(output_dir, file_name)
+                out_path = _unique_path(output_dir, file_name)
                 current_doc.save(out_path)
                 created_files.append(out_path)
             current_doc = Document()
@@ -68,7 +77,7 @@ def split_document(file_path: str) -> List[str]:
         if not sanitized:
             sanitized = "section"
         file_name = f"{sanitized}.docx"
-        out_path = os.path.join(output_dir, file_name)
+        out_path = _unique_path(output_dir, file_name)
         current_doc.save(out_path)
         created_files.append(out_path)
 

--- a/tests/test_split_document.py
+++ b/tests/test_split_document.py
@@ -37,3 +37,23 @@ def test_split_document(tmp_path):
         texts = [p.text.strip() for p in doc.paragraphs if p.text.strip()]
         assert all(not heading_pattern.match(t) for t in texts)
 
+
+def create_duplicate_doc(path):
+    doc = Document()
+    doc.add_paragraph("Глава 1")
+    doc.add_paragraph("Text for chapter 1")
+    doc.add_paragraph("Глава 1")
+    doc.add_paragraph("Another text")
+    doc.save(path)
+
+
+def test_split_document_duplicate_titles(tmp_path):
+    source = tmp_path / "dup_source.docx"
+    create_duplicate_doc(source)
+
+    with patch("cod.filedialog.askdirectory", return_value=str(tmp_path)):
+        created_files = split_document(str(source))
+
+    expected_names = {"Глава 1.docx", "Глава 1 (2).docx"}
+    assert {os.path.basename(p) for p in created_files} == expected_names
+


### PR DESCRIPTION
## Summary
- Avoid overwriting existing chapter files by checking for name conflicts and appending numeric suffixes.
- Add regression test to verify duplicate chapter titles produce suffixed filenames.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd47ebd5f08332be0798ebac544ec2