### PR TITLE
Add authentication parameters for Rulate uploads

### DIFF
--- a/cod.py
+++ b/cod.py
@@ -454,7 +454,7 @@ class Application(tk.Tk):
         inputs = {}
         fields = [
             ("URL книги", "book_url", False),
-            ("Логин", "login", False),
+            ("Логин", "username", False),
             ("Пароль", "password", True),
             ("Том", "volume", False),
             ("Дата/время публикации", "publish_at", False),
@@ -507,7 +507,7 @@ class Application(tk.Tk):
         def submit():
             dialog.destroy()
             book_url = inputs["book_url"].get().strip()
-            login = inputs["login"].get().strip() or None
+            username = inputs["username"].get().strip() or None
             password = inputs["password"].get() or None
             volume_text = inputs["volume"].get().strip()
             volume = int(volume_text) if volume_text else None
@@ -519,7 +519,7 @@ class Application(tk.Tk):
                 results = upload_chapters(
                     book_url,
                     files,
-                    login=login,
+                    username=username,
                     password=password,
                     deferred=deferred,
                     subscription=subscription,

--- a/rulate_cli.py
+++ b/rulate_cli.py
@@ -10,6 +10,8 @@ def main(argv: List[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Upload chapter files to rulate.ru")
     parser.add_argument("book_url", help="Base URL of the book on rulate.ru")
     parser.add_argument("files", nargs="+", help="Chapter files to upload")
+    parser.add_argument("--username", help="Username for authentication")
+    parser.add_argument("--password", help="Password for authentication")
     parser.add_argument("--deferred", action="store_true", help="Upload chapters as deferred")
     parser.add_argument("--subscription", action="store_true", help="Require subscription to read")
     parser.add_argument("--volume", type=int, help="Volume number for uploaded chapters")
@@ -27,6 +29,8 @@ def main(argv: List[str] | None = None) -> None:
     results = upload_chapters(
         args.book_url,
         args.files,
+        username=args.username,
+        password=args.password,
         deferred=args.deferred,
         subscription=args.subscription,
         volume=args.volume,

--- a/rulate_uploader.py
+++ b/rulate_uploader.py
@@ -28,7 +28,7 @@ def upload_chapters(
     book_url: str,
     files: Iterable[str],
     *,
-    login: str | None = None,
+    username: str | None = None,
     password: str | None = None,
     deferred: bool = False,
     subscription: bool = False,
@@ -45,11 +45,11 @@ def upload_chapters(
         ``/chapter/new`` endpoint of this URL when uploading.
     files:
         Iterable of paths to chapter documents that should be uploaded.
-    login:
+    username:
         Username for authentication. If provided with ``password`` the function
         will attempt to log in before uploading.
     password:
-        Password for authentication. Used together with ``login``.
+        Password for authentication. Used together with ``username``.
     deferred:
         If ``True`` the chapters will be marked as deferred (draft mode).
     subscription:
@@ -79,14 +79,16 @@ def upload_chapters(
     results: Dict[str, bool] = {}
 
     try:
-        if login and password:
+        if username and password:
             try:
-                driver.get("https://tl.rulate.ru/user/login")
-                login_input = wait.until(
-                    EC.presence_of_element_located((By.NAME, "login"))
+                driver.get("https://tl.rulate.ru/")
+                user_input = wait.until(
+                    EC.presence_of_element_located(
+                        (By.NAME, "LoginForm[username]")
+                    )
                 )
-                pass_input = driver.find_element(By.NAME, "password")
-                login_input.send_keys(login)
+                pass_input = driver.find_element(By.NAME, "LoginForm[password]")
+                user_input.send_keys(username)
                 pass_input.send_keys(password)
                 pass_input.submit()
                 try:


### PR DESCRIPTION
## Summary
- support username/password login before uploading
- accept authentication flags in CLI and GUI dialogs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd4f01bd8c8332ac6e5933a44daab7