### PR TITLE
Fix dialog destruction timing

### DIFF
--- a/cod.py
+++ b/cod.py
@@ -505,7 +505,6 @@ class Application(tk.Tk):
         button_frame.pack(pady=(0, 10))
 
         def submit():
-            dialog.destroy()
             book_url = inputs["book_url"].get().strip()
             username = inputs["username"].get().strip() or None
             password = inputs["password"].get() or None
@@ -514,6 +513,8 @@ class Application(tk.Tk):
             publish_at = inputs["publish_at"].get().strip() or None
             deferred = bool(deferred_var.get())
             subscription = bool(subscription_var.get())
+
+            dialog.destroy()
 
             try:
                 results = upload_chapters(


### PR DESCRIPTION
## Summary
- Read user input before destroying the dialog window to prevent Tkinter errors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd5313405c8332a2cdbe69a54d9771